### PR TITLE
Supporting JSON with comment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"requires": {
-				"acorn": "3.3.0"
+				"acorn": "^3.0.4"
 			},
 			"dependencies": {
 				"acorn": {
@@ -45,10 +45,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ajv-keywords": {
@@ -105,7 +105,7 @@
 			"integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
 			"dev": true,
 			"requires": {
-				"buffer-equal": "1.0.0"
+				"buffer-equal": "^1.0.0"
 			}
 		},
 		"argparse": {
@@ -114,7 +114,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"arr-diff": {
@@ -123,8 +123,8 @@
 			"integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "1.1.0",
-				"array-slice": "0.2.3"
+				"arr-flatten": "^1.0.1",
+				"array-slice": "^0.2.3"
 			}
 		},
 		"arr-flatten": {
@@ -157,7 +157,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
 			}
 		},
 		"array-uniq": {
@@ -178,7 +178,7 @@
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": "~2.1.0"
 			}
 		},
 		"assert-plus": {
@@ -211,9 +211,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
 				"chalk": {
@@ -222,11 +222,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -235,7 +235,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				}
 			}
@@ -252,7 +252,7 @@
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"dev": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"block-stream": {
@@ -261,7 +261,7 @@
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "~2.0.0"
 			}
 		},
 		"brace-expansion": {
@@ -270,7 +270,7 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -304,7 +304,7 @@
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "0.2.0"
+				"callsites": "^0.2.0"
 			}
 		},
 		"callsites": {
@@ -325,9 +325,9 @@
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.5.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -336,7 +336,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.3"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"supports-color": {
@@ -345,7 +345,7 @@
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -368,7 +368,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "2.0.0"
+				"restore-cursor": "^2.0.0"
 			}
 		},
 		"cli-width": {
@@ -401,9 +401,9 @@
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"process-nextick-args": "2.0.0",
-				"readable-stream": "2.3.6"
+				"inherits": "^2.0.1",
+				"process-nextick-args": "^2.0.0",
+				"readable-stream": "^2.3.5"
 			}
 		},
 		"co": {
@@ -433,7 +433,7 @@
 			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
@@ -454,10 +454,10 @@
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.1",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6",
-				"typedarray": "0.0.6"
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
 			}
 		},
 		"convert-source-map": {
@@ -466,7 +466,7 @@
 			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.1"
 			}
 		},
 		"core-util-is": {
@@ -481,9 +481,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.5",
-				"shebang-command": "1.2.0",
-				"which": "1.3.1"
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"dashdash": {
@@ -492,7 +492,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"debug": {
@@ -501,7 +501,7 @@
 			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 			"dev": true,
 			"requires": {
-				"ms": "2.1.1"
+				"ms": "^2.1.1"
 			}
 		},
 		"deep-assign": {
@@ -510,7 +510,7 @@
 			"integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
 			"dev": true,
 			"requires": {
-				"is-obj": "1.0.1"
+				"is-obj": "^1.0.0"
 			}
 		},
 		"deep-is": {
@@ -525,7 +525,7 @@
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
 			"dev": true,
 			"requires": {
-				"object-keys": "1.0.12"
+				"object-keys": "^1.0.12"
 			}
 		},
 		"delayed-stream": {
@@ -546,7 +546,7 @@
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
-				"esutils": "2.0.2"
+				"esutils": "^2.0.2"
 			}
 		},
 		"duplexer": {
@@ -561,10 +561,10 @@
 			"integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.1",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6",
-				"stream-shift": "1.0.0"
+				"end-of-stream": "^1.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0",
+				"stream-shift": "^1.0.0"
 			}
 		},
 		"ecc-jsbn": {
@@ -573,8 +573,8 @@
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"dev": true,
 			"requires": {
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"end-of-stream": {
@@ -583,7 +583,7 @@
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0"
+				"once": "^1.4.0"
 			}
 		},
 		"escape-string-regexp": {
@@ -598,44 +598,44 @@
 			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"babel-code-frame": "6.26.0",
-				"chalk": "2.4.1",
-				"concat-stream": "1.6.2",
-				"cross-spawn": "5.1.0",
-				"debug": "3.2.6",
-				"doctrine": "2.1.0",
-				"eslint-scope": "3.7.3",
-				"eslint-visitor-keys": "1.0.0",
-				"espree": "3.5.4",
-				"esquery": "1.0.1",
-				"esutils": "2.0.2",
-				"file-entry-cache": "2.0.0",
-				"functional-red-black-tree": "1.0.1",
-				"glob": "7.1.3",
-				"globals": "11.9.0",
-				"ignore": "3.3.10",
-				"imurmurhash": "0.1.4",
-				"inquirer": "3.3.0",
-				"is-resolvable": "1.1.0",
-				"js-yaml": "3.12.0",
-				"json-stable-stringify-without-jsonify": "1.0.1",
-				"levn": "0.3.0",
-				"lodash": "4.17.11",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"optionator": "0.8.2",
-				"path-is-inside": "1.0.2",
-				"pluralize": "7.0.0",
-				"progress": "2.0.3",
-				"regexpp": "1.1.0",
-				"require-uncached": "1.0.3",
-				"semver": "5.6.0",
-				"strip-ansi": "4.0.0",
-				"strip-json-comments": "2.0.1",
+				"ajv": "^5.3.0",
+				"babel-code-frame": "^6.22.0",
+				"chalk": "^2.1.0",
+				"concat-stream": "^1.6.0",
+				"cross-spawn": "^5.1.0",
+				"debug": "^3.1.0",
+				"doctrine": "^2.1.0",
+				"eslint-scope": "^3.7.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^3.5.4",
+				"esquery": "^1.0.0",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^2.0.0",
+				"functional-red-black-tree": "^1.0.1",
+				"glob": "^7.1.2",
+				"globals": "^11.0.1",
+				"ignore": "^3.3.3",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^3.0.6",
+				"is-resolvable": "^1.0.0",
+				"js-yaml": "^3.9.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.2",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"path-is-inside": "^1.0.2",
+				"pluralize": "^7.0.0",
+				"progress": "^2.0.0",
+				"regexpp": "^1.0.1",
+				"require-uncached": "^1.0.3",
+				"semver": "^5.3.0",
+				"strip-ansi": "^4.0.0",
+				"strip-json-comments": "~2.0.1",
 				"table": "4.0.2",
-				"text-table": "0.2.0"
+				"text-table": "~0.2.0"
 			}
 		},
 		"eslint-scope": {
@@ -644,8 +644,8 @@
 			"integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
 			"dev": true,
 			"requires": {
-				"esrecurse": "4.2.1",
-				"estraverse": "4.2.0"
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -660,8 +660,8 @@
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.7.3",
-				"acorn-jsx": "3.0.1"
+				"acorn": "^5.5.0",
+				"acorn-jsx": "^3.0.0"
 			}
 		},
 		"esprima": {
@@ -676,7 +676,7 @@
 			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.0.0"
 			}
 		},
 		"esrecurse": {
@@ -685,7 +685,7 @@
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.1.0"
 			}
 		},
 		"estraverse": {
@@ -706,13 +706,13 @@
 			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
 			"dev": true,
 			"requires": {
-				"duplexer": "0.1.1",
-				"from": "0.1.7",
-				"map-stream": "0.1.0",
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
 				"pause-stream": "0.0.11",
-				"split": "0.3.3",
-				"stream-combiner": "0.0.4",
-				"through": "2.3.8"
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
 			}
 		},
 		"extend": {
@@ -727,7 +727,7 @@
 			"integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
 			"dev": true,
 			"requires": {
-				"kind-of": "1.1.0"
+				"kind-of": "^1.1.0"
 			}
 		},
 		"external-editor": {
@@ -736,9 +736,9 @@
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"dev": true,
 			"requires": {
-				"chardet": "0.4.2",
-				"iconv-lite": "0.4.24",
-				"tmp": "0.0.33"
+				"chardet": "^0.4.0",
+				"iconv-lite": "^0.4.17",
+				"tmp": "^0.0.33"
 			}
 		},
 		"extsprintf": {
@@ -771,7 +771,7 @@
 			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
 			"dev": true,
 			"requires": {
-				"pend": "1.2.0"
+				"pend": "~1.2.0"
 			}
 		},
 		"figures": {
@@ -780,7 +780,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -789,8 +789,8 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "1.3.4",
-				"object-assign": "4.1.1"
+				"flat-cache": "^1.2.1",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"flat-cache": {
@@ -799,10 +799,10 @@
 			"integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
 			"dev": true,
 			"requires": {
-				"circular-json": "0.3.3",
-				"graceful-fs": "4.1.15",
-				"rimraf": "2.6.2",
-				"write": "0.2.1"
+				"circular-json": "^0.3.1",
+				"graceful-fs": "^4.1.2",
+				"rimraf": "~2.6.2",
+				"write": "^0.2.1"
 			}
 		},
 		"flush-write-stream": {
@@ -811,8 +811,8 @@
 			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6"
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.4"
 			}
 		},
 		"forever-agent": {
@@ -827,9 +827,9 @@
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"dev": true,
 			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.7",
-				"mime-types": "2.1.21"
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
 			}
 		},
 		"from": {
@@ -844,8 +844,8 @@
 			"integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.15",
-				"through2": "2.0.5"
+				"graceful-fs": "^4.1.11",
+				"through2": "^2.0.3"
 			}
 		},
 		"fs.realpath": {
@@ -860,10 +860,10 @@
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.15",
-				"inherits": "2.0.3",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2"
+				"graceful-fs": "^4.1.2",
+				"inherits": "~2.0.0",
+				"mkdirp": ">=0.5 0",
+				"rimraf": "2"
 			}
 		},
 		"function-bind": {
@@ -884,7 +884,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -893,12 +893,12 @@
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-parent": {
@@ -907,8 +907,8 @@
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"dev": true,
 			"requires": {
-				"is-glob": "3.1.0",
-				"path-dirname": "1.0.2"
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
 			}
 		},
 		"glob-stream": {
@@ -917,16 +917,16 @@
 			"integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
 			"dev": true,
 			"requires": {
-				"extend": "3.0.2",
-				"glob": "7.1.3",
-				"glob-parent": "3.1.0",
-				"is-negated-glob": "1.0.0",
-				"ordered-read-streams": "1.0.1",
-				"pumpify": "1.5.1",
-				"readable-stream": "2.3.6",
-				"remove-trailing-separator": "1.1.0",
-				"to-absolute-glob": "2.0.2",
-				"unique-stream": "2.2.1"
+				"extend": "^3.0.0",
+				"glob": "^7.1.1",
+				"glob-parent": "^3.1.0",
+				"is-negated-glob": "^1.0.0",
+				"ordered-read-streams": "^1.0.0",
+				"pumpify": "^1.3.5",
+				"readable-stream": "^2.1.5",
+				"remove-trailing-separator": "^1.0.1",
+				"to-absolute-glob": "^2.0.0",
+				"unique-stream": "^2.0.2"
 			}
 		},
 		"globals": {
@@ -953,9 +953,9 @@
 			"integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
 			"dev": true,
 			"requires": {
-				"deep-assign": "1.0.0",
-				"stat-mode": "0.2.2",
-				"through2": "2.0.5"
+				"deep-assign": "^1.0.0",
+				"stat-mode": "^0.2.0",
+				"through2": "^2.0.0"
 			}
 		},
 		"gulp-filter": {
@@ -964,9 +964,9 @@
 			"integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
 			"dev": true,
 			"requires": {
-				"multimatch": "2.1.0",
-				"plugin-error": "0.1.2",
-				"streamfilter": "1.0.7"
+				"multimatch": "^2.0.0",
+				"plugin-error": "^0.1.2",
+				"streamfilter": "^1.0.5"
 			}
 		},
 		"gulp-gunzip": {
@@ -975,8 +975,8 @@
 			"integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
 			"dev": true,
 			"requires": {
-				"through2": "0.6.5",
-				"vinyl": "0.4.6"
+				"through2": "~0.6.5",
+				"vinyl": "~0.4.6"
 			},
 			"dependencies": {
 				"isarray": {
@@ -991,10 +991,10 @@
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
 				},
 				"string_decoder": {
@@ -1009,8 +1009,8 @@
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
 					"dev": true,
 					"requires": {
-						"readable-stream": "1.0.34",
-						"xtend": "4.0.1"
+						"readable-stream": ">=1.0.33-1 <1.1.0-0",
+						"xtend": ">=4.0.0 <4.1.0-0"
 					}
 				}
 			}
@@ -1022,10 +1022,10 @@
 			"dev": true,
 			"requires": {
 				"event-stream": "3.3.4",
-				"node.extend": "1.1.8",
-				"request": "2.88.0",
-				"through2": "2.0.5",
-				"vinyl": "2.2.0"
+				"node.extend": "^1.1.2",
+				"request": "^2.79.0",
+				"through2": "^2.0.3",
+				"vinyl": "^2.0.1"
 			},
 			"dependencies": {
 				"clone": {
@@ -1046,12 +1046,12 @@
 					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
 					"dev": true,
 					"requires": {
-						"clone": "2.1.2",
-						"clone-buffer": "1.0.0",
-						"clone-stats": "1.0.0",
-						"cloneable-readable": "1.1.2",
-						"remove-trailing-separator": "1.1.0",
-						"replace-ext": "1.0.0"
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
 					}
 				}
 			}
@@ -1062,11 +1062,11 @@
 			"integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
 			"dev": true,
 			"requires": {
-				"event-stream": "3.3.4",
-				"streamifier": "0.1.1",
-				"tar": "2.2.1",
-				"through2": "2.0.5",
-				"vinyl": "1.2.0"
+				"event-stream": "~3.3.4",
+				"streamifier": "~0.1.1",
+				"tar": "^2.2.1",
+				"through2": "~2.0.3",
+				"vinyl": "^1.2.0"
 			},
 			"dependencies": {
 				"clone": {
@@ -1087,8 +1087,8 @@
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
 					"dev": true,
 					"requires": {
-						"clone": "1.0.4",
-						"clone-stats": "0.0.1",
+						"clone": "^1.0.0",
+						"clone-stats": "^0.0.1",
 						"replace-ext": "0.0.1"
 					}
 				}
@@ -1101,12 +1101,12 @@
 			"dev": true,
 			"requires": {
 				"event-stream": "3.3.4",
-				"queue": "4.5.1",
-				"through2": "2.0.5",
-				"vinyl": "2.2.0",
-				"vinyl-fs": "3.0.3",
-				"yauzl": "2.10.0",
-				"yazl": "2.5.1"
+				"queue": "^4.2.1",
+				"through2": "^2.0.3",
+				"vinyl": "^2.0.2",
+				"vinyl-fs": "^3.0.3",
+				"yauzl": "^2.2.1",
+				"yazl": "^2.2.1"
 			},
 			"dependencies": {
 				"clone": {
@@ -1127,12 +1127,12 @@
 					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
 					"dev": true,
 					"requires": {
-						"clone": "2.1.2",
-						"clone-buffer": "1.0.0",
-						"clone-stats": "1.0.0",
-						"cloneable-readable": "1.1.2",
-						"remove-trailing-separator": "1.1.0",
-						"replace-ext": "1.0.0"
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
 					}
 				}
 			}
@@ -1149,8 +1149,8 @@
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
 			"dev": true,
 			"requires": {
-				"ajv": "6.6.2",
-				"har-schema": "2.0.0"
+				"ajv": "^6.5.5",
+				"har-schema": "^2.0.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -1159,10 +1159,10 @@
 					"integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "2.0.1",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.4.1",
-						"uri-js": "4.2.2"
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
 					}
 				},
 				"fast-deep-equal": {
@@ -1185,7 +1185,7 @@
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -1194,7 +1194,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -1221,9 +1221,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.16.0"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"iconv-lite": {
@@ -1232,7 +1232,7 @@
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
 		"ignore": {
@@ -1253,8 +1253,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -1269,20 +1269,20 @@
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "3.1.0",
-				"chalk": "2.4.1",
-				"cli-cursor": "2.1.0",
-				"cli-width": "2.2.0",
-				"external-editor": "2.2.0",
-				"figures": "2.0.0",
-				"lodash": "4.17.11",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^2.0.4",
+				"figures": "^2.0.0",
+				"lodash": "^4.3.0",
 				"mute-stream": "0.0.7",
-				"run-async": "2.3.0",
-				"rx-lite": "4.0.8",
-				"rx-lite-aggregates": "4.0.8",
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"through": "2.3.8"
+				"run-async": "^2.2.0",
+				"rx-lite": "^4.0.8",
+				"rx-lite-aggregates": "^4.0.8",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^4.0.0",
+				"through": "^2.3.6"
 			}
 		},
 		"is": {
@@ -1297,8 +1297,8 @@
 			"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
 			"dev": true,
 			"requires": {
-				"is-relative": "1.0.0",
-				"is-windows": "1.0.2"
+				"is-relative": "^1.0.0",
+				"is-windows": "^1.0.1"
 			}
 		},
 		"is-buffer": {
@@ -1325,7 +1325,7 @@
 			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "2.1.1"
+				"is-extglob": "^2.1.0"
 			}
 		},
 		"is-negated-glob": {
@@ -1352,7 +1352,7 @@
 			"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
 			"dev": true,
 			"requires": {
-				"is-unc-path": "1.0.0"
+				"is-unc-path": "^1.0.0"
 			}
 		},
 		"is-resolvable": {
@@ -1373,7 +1373,7 @@
 			"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
 			"dev": true,
 			"requires": {
-				"unc-path-regex": "0.1.2"
+				"unc-path-regex": "^0.1.2"
 			}
 		},
 		"is-utf8": {
@@ -1424,8 +1424,8 @@
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -1452,7 +1452,7 @@
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"dev": true,
 			"requires": {
-				"jsonify": "0.0.0"
+				"jsonify": "~0.0.0"
 			}
 		},
 		"json-stable-stringify-without-jsonify": {
@@ -1466,6 +1466,11 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
+		},
+		"jsonc-parser": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.0.3.tgz",
+			"integrity": "sha512-WJi9y9ABL01C8CxTKxRRQkkSpY/x2bo4Gy0WuiZGrInxQqgxQpvkBCLNcDYcHOSdhx4ODgbFcgAvfL49C+PHgQ=="
 		},
 		"jsonify": {
 			"version": "0.0.0",
@@ -1497,7 +1502,7 @@
 			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.6"
+				"readable-stream": "^2.0.5"
 			}
 		},
 		"lead": {
@@ -1506,7 +1511,7 @@
 			"integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
 			"dev": true,
 			"requires": {
-				"flush-write-stream": "1.0.3"
+				"flush-write-stream": "^1.0.2"
 			}
 		},
 		"levn": {
@@ -1515,8 +1520,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"lodash": {
@@ -1531,8 +1536,8 @@
 			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"map-stream": {
@@ -1553,7 +1558,7 @@
 			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.37.0"
+				"mime-db": "~1.37.0"
 			}
 		},
 		"mimic-fn": {
@@ -1568,7 +1573,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -1619,12 +1624,12 @@
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"dev": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-flag": {
@@ -1645,7 +1650,7 @@
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -1662,10 +1667,10 @@
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
 			"dev": true,
 			"requires": {
-				"array-differ": "1.0.0",
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"minimatch": "3.0.4"
+				"array-differ": "^1.0.0",
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"minimatch": "^3.0.0"
 			}
 		},
 		"mute-stream": {
@@ -1686,8 +1691,8 @@
 			"integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
 			"dev": true,
 			"requires": {
-				"has": "1.0.3",
-				"is": "3.3.0"
+				"has": "^1.0.3",
+				"is": "^3.2.1"
 			}
 		},
 		"normalize-path": {
@@ -1696,7 +1701,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"now-and-later": {
@@ -1705,7 +1710,7 @@
 			"integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0"
+				"once": "^1.3.2"
 			}
 		},
 		"oauth-sign": {
@@ -1732,10 +1737,10 @@
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.3",
-				"function-bind": "1.1.1",
-				"has-symbols": "1.0.0",
-				"object-keys": "1.0.12"
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
 			}
 		},
 		"once": {
@@ -1744,7 +1749,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
@@ -1753,7 +1758,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"optionator": {
@@ -1762,12 +1767,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			}
 		},
 		"ordered-read-streams": {
@@ -1776,7 +1781,7 @@
 			"integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.6"
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"os-tmpdir": {
@@ -1809,7 +1814,7 @@
 			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
 			"dev": true,
 			"requires": {
-				"through": "2.3.8"
+				"through": "~2.3"
 			}
 		},
 		"pend": {
@@ -1830,11 +1835,11 @@
 			"integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
 			"dev": true,
 			"requires": {
-				"ansi-cyan": "0.1.1",
-				"ansi-red": "0.1.1",
-				"arr-diff": "1.1.0",
-				"arr-union": "2.1.0",
-				"extend-shallow": "1.1.4"
+				"ansi-cyan": "^0.1.1",
+				"ansi-red": "^0.1.1",
+				"arr-diff": "^1.0.1",
+				"arr-union": "^2.0.1",
+				"extend-shallow": "^1.1.2"
 			}
 		},
 		"pluralize": {
@@ -1879,8 +1884,8 @@
 			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.1",
-				"once": "1.4.0"
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
 			}
 		},
 		"pumpify": {
@@ -1889,9 +1894,9 @@
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
 			"dev": true,
 			"requires": {
-				"duplexify": "3.6.1",
-				"inherits": "2.0.3",
-				"pump": "2.0.1"
+				"duplexify": "^3.6.0",
+				"inherits": "^2.0.3",
+				"pump": "^2.0.0"
 			}
 		},
 		"punycode": {
@@ -1918,7 +1923,7 @@
 			"integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "~2.0.0"
 			}
 		},
 		"readable-stream": {
@@ -1927,13 +1932,13 @@
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"regexpp": {
@@ -1948,8 +1953,8 @@
 			"integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
 			"dev": true,
 			"requires": {
-				"is-buffer": "1.1.6",
-				"is-utf8": "0.2.1"
+				"is-buffer": "^1.1.5",
+				"is-utf8": "^0.2.1"
 			}
 		},
 		"remove-bom-stream": {
@@ -1958,9 +1963,9 @@
 			"integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
 			"dev": true,
 			"requires": {
-				"remove-bom-buffer": "3.0.0",
-				"safe-buffer": "5.1.2",
-				"through2": "2.0.5"
+				"remove-bom-buffer": "^3.0.0",
+				"safe-buffer": "^5.1.0",
+				"through2": "^2.0.3"
 			}
 		},
 		"remove-trailing-separator": {
@@ -1981,26 +1986,26 @@
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.8.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.7",
-				"extend": "3.0.2",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.3",
-				"har-validator": "5.1.3",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.21",
-				"oauth-sign": "0.9.0",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.4.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.3.2"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
 			}
 		},
 		"require-uncached": {
@@ -2009,8 +2014,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "0.1.0",
-				"resolve-from": "1.0.1"
+				"caller-path": "^0.1.0",
+				"resolve-from": "^1.0.0"
 			}
 		},
 		"requires-port": {
@@ -2031,7 +2036,7 @@
 			"integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
 			"dev": true,
 			"requires": {
-				"value-or-function": "3.0.0"
+				"value-or-function": "^3.0.0"
 			}
 		},
 		"restore-cursor": {
@@ -2040,8 +2045,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "2.0.1",
-				"signal-exit": "3.0.2"
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"rimraf": {
@@ -2050,7 +2055,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.3"
+				"glob": "^7.0.5"
 			}
 		},
 		"run-async": {
@@ -2059,7 +2064,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "2.1.0"
+				"is-promise": "^2.1.0"
 			}
 		},
 		"rx-lite": {
@@ -2074,7 +2079,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "4.0.8"
+				"rx-lite": "*"
 			}
 		},
 		"safe-buffer": {
@@ -2101,7 +2106,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -2122,7 +2127,7 @@
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0"
+				"is-fullwidth-code-point": "^2.0.0"
 			}
 		},
 		"source-map": {
@@ -2137,8 +2142,8 @@
 			"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.1",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"split": {
@@ -2147,7 +2152,7 @@
 			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
 			"dev": true,
 			"requires": {
-				"through": "2.3.8"
+				"through": "2"
 			}
 		},
 		"sprintf-js": {
@@ -2162,15 +2167,15 @@
 			"integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
 			"dev": true,
 			"requires": {
-				"asn1": "0.2.4",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.2",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.2",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stat-mode": {
@@ -2185,7 +2190,7 @@
 			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
 			"dev": true,
 			"requires": {
-				"duplexer": "0.1.1"
+				"duplexer": "~0.1.1"
 			}
 		},
 		"stream-shift": {
@@ -2200,7 +2205,7 @@
 			"integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.6"
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"streamifier": {
@@ -2215,8 +2220,8 @@
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
 			}
 		},
 		"string_decoder": {
@@ -2225,7 +2230,7 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -2234,7 +2239,7 @@
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "3.0.0"
+				"ansi-regex": "^3.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -2263,12 +2268,12 @@
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"ajv-keywords": "2.1.1",
-				"chalk": "2.4.1",
-				"lodash": "4.17.11",
+				"ajv": "^5.2.3",
+				"ajv-keywords": "^2.1.0",
+				"chalk": "^2.1.0",
+				"lodash": "^4.17.4",
 				"slice-ansi": "1.0.0",
-				"string-width": "2.1.1"
+				"string-width": "^2.1.1"
 			}
 		},
 		"tar": {
@@ -2277,9 +2282,9 @@
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 			"dev": true,
 			"requires": {
-				"block-stream": "0.0.9",
-				"fstream": "1.0.11",
-				"inherits": "2.0.3"
+				"block-stream": "*",
+				"fstream": "^1.0.2",
+				"inherits": "2"
 			}
 		},
 		"text-table": {
@@ -2300,8 +2305,8 @@
 			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.6",
-				"xtend": "4.0.1"
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
 			}
 		},
 		"through2-filter": {
@@ -2310,8 +2315,8 @@
 			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
 			"dev": true,
 			"requires": {
-				"through2": "2.0.5",
-				"xtend": "4.0.1"
+				"through2": "~2.0.0",
+				"xtend": "~4.0.0"
 			}
 		},
 		"tmp": {
@@ -2320,7 +2325,7 @@
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "1.0.2"
+				"os-tmpdir": "~1.0.2"
 			}
 		},
 		"to-absolute-glob": {
@@ -2329,8 +2334,8 @@
 			"integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
 			"dev": true,
 			"requires": {
-				"is-absolute": "1.0.0",
-				"is-negated-glob": "1.0.0"
+				"is-absolute": "^1.0.0",
+				"is-negated-glob": "^1.0.0"
 			}
 		},
 		"to-through": {
@@ -2339,7 +2344,7 @@
 			"integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
 			"dev": true,
 			"requires": {
-				"through2": "2.0.5"
+				"through2": "^2.0.3"
 			}
 		},
 		"tough-cookie": {
@@ -2348,8 +2353,8 @@
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"dev": true,
 			"requires": {
-				"psl": "1.1.31",
-				"punycode": "1.4.1"
+				"psl": "^1.1.24",
+				"punycode": "^1.4.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -2366,7 +2371,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -2381,7 +2386,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"typedarray": {
@@ -2408,8 +2413,8 @@
 			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
 			"dev": true,
 			"requires": {
-				"json-stable-stringify": "1.0.1",
-				"through2-filter": "2.0.0"
+				"json-stable-stringify": "^1.0.0",
+				"through2-filter": "^2.0.0"
 			}
 		},
 		"uri-js": {
@@ -2418,7 +2423,7 @@
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 			"dev": true,
 			"requires": {
-				"punycode": "2.1.1"
+				"punycode": "^2.1.0"
 			}
 		},
 		"url-parse": {
@@ -2427,8 +2432,8 @@
 			"integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
 			"dev": true,
 			"requires": {
-				"querystringify": "2.1.0",
-				"requires-port": "1.0.0"
+				"querystringify": "^2.0.0",
+				"requires-port": "^1.0.0"
 			}
 		},
 		"util-deprecate": {
@@ -2455,9 +2460,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"vinyl": {
@@ -2466,8 +2471,8 @@
 			"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
 			"dev": true,
 			"requires": {
-				"clone": "0.2.0",
-				"clone-stats": "0.0.1"
+				"clone": "^0.2.0",
+				"clone-stats": "^0.0.1"
 			}
 		},
 		"vinyl-fs": {
@@ -2476,23 +2481,23 @@
 			"integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
 			"dev": true,
 			"requires": {
-				"fs-mkdirp-stream": "1.0.0",
-				"glob-stream": "6.1.0",
-				"graceful-fs": "4.1.15",
-				"is-valid-glob": "1.0.0",
-				"lazystream": "1.0.0",
-				"lead": "1.0.0",
-				"object.assign": "4.1.0",
-				"pumpify": "1.5.1",
-				"readable-stream": "2.3.6",
-				"remove-bom-buffer": "3.0.0",
-				"remove-bom-stream": "1.2.0",
-				"resolve-options": "1.1.0",
-				"through2": "2.0.5",
-				"to-through": "2.0.0",
-				"value-or-function": "3.0.0",
-				"vinyl": "2.2.0",
-				"vinyl-sourcemap": "1.1.0"
+				"fs-mkdirp-stream": "^1.0.0",
+				"glob-stream": "^6.1.0",
+				"graceful-fs": "^4.0.0",
+				"is-valid-glob": "^1.0.0",
+				"lazystream": "^1.0.0",
+				"lead": "^1.0.0",
+				"object.assign": "^4.0.4",
+				"pumpify": "^1.3.5",
+				"readable-stream": "^2.3.3",
+				"remove-bom-buffer": "^3.0.0",
+				"remove-bom-stream": "^1.2.0",
+				"resolve-options": "^1.1.0",
+				"through2": "^2.0.0",
+				"to-through": "^2.0.0",
+				"value-or-function": "^3.0.0",
+				"vinyl": "^2.0.0",
+				"vinyl-sourcemap": "^1.1.0"
 			},
 			"dependencies": {
 				"clone": {
@@ -2513,12 +2518,12 @@
 					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
 					"dev": true,
 					"requires": {
-						"clone": "2.1.2",
-						"clone-buffer": "1.0.0",
-						"clone-stats": "1.0.0",
-						"cloneable-readable": "1.1.2",
-						"remove-trailing-separator": "1.1.0",
-						"replace-ext": "1.0.0"
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
 					}
 				}
 			}
@@ -2529,8 +2534,8 @@
 			"integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
 			"dev": true,
 			"requires": {
-				"through2": "2.0.5",
-				"vinyl": "0.4.6"
+				"through2": "^2.0.3",
+				"vinyl": "^0.4.3"
 			}
 		},
 		"vinyl-sourcemap": {
@@ -2539,13 +2544,13 @@
 			"integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
 			"dev": true,
 			"requires": {
-				"append-buffer": "1.0.2",
-				"convert-source-map": "1.6.0",
-				"graceful-fs": "4.1.15",
-				"normalize-path": "2.1.1",
-				"now-and-later": "2.0.0",
-				"remove-bom-buffer": "3.0.0",
-				"vinyl": "2.2.0"
+				"append-buffer": "^1.0.2",
+				"convert-source-map": "^1.5.0",
+				"graceful-fs": "^4.1.6",
+				"normalize-path": "^2.1.1",
+				"now-and-later": "^2.0.0",
+				"remove-bom-buffer": "^3.0.0",
+				"vinyl": "^2.0.0"
 			},
 			"dependencies": {
 				"clone": {
@@ -2566,12 +2571,12 @@
 					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
 					"dev": true,
 					"requires": {
-						"clone": "2.1.2",
-						"clone-buffer": "1.0.0",
-						"clone-stats": "1.0.0",
-						"cloneable-readable": "1.1.2",
-						"remove-trailing-separator": "1.1.0",
-						"replace-ext": "1.0.0"
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
 					}
 				}
 			}
@@ -2582,20 +2587,20 @@
 			"integrity": "sha512-z1Nf5J38gjUFbuDCbJHPN6OJ//5EG+e/yHlh6ERxj/U9B2Qc3aiHaFr38/fee/GGnxvRw/XegLMOG+UJwKi/Qg==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.3",
-				"gulp-chmod": "2.0.0",
-				"gulp-filter": "5.1.0",
+				"glob": "^7.1.2",
+				"gulp-chmod": "^2.0.0",
+				"gulp-filter": "^5.0.1",
 				"gulp-gunzip": "1.0.0",
-				"gulp-remote-src-vscode": "0.5.1",
-				"gulp-untar": "0.0.7",
-				"gulp-vinyl-zip": "2.1.2",
-				"mocha": "4.1.0",
-				"request": "2.88.0",
-				"semver": "5.6.0",
-				"source-map-support": "0.5.9",
-				"url-parse": "1.4.4",
-				"vinyl-fs": "3.0.3",
-				"vinyl-source-stream": "1.1.2"
+				"gulp-remote-src-vscode": "^0.5.1",
+				"gulp-untar": "^0.0.7",
+				"gulp-vinyl-zip": "^2.1.2",
+				"mocha": "^4.0.1",
+				"request": "^2.88.0",
+				"semver": "^5.4.1",
+				"source-map-support": "^0.5.0",
+				"url-parse": "^1.4.3",
+				"vinyl-fs": "^3.0.3",
+				"vinyl-source-stream": "^1.1.0"
 			}
 		},
 		"which": {
@@ -2604,7 +2609,7 @@
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"wordwrap": {
@@ -2625,7 +2630,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "0.5.1"
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"xtend": {
@@ -2646,8 +2651,8 @@
 			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
 			"dev": true,
 			"requires": {
-				"buffer-crc32": "0.2.13",
-				"fd-slicer": "1.1.0"
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
 			}
 		},
 		"yazl": {
@@ -2656,7 +2661,7 @@
 			"integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
 			"dev": true,
 			"requires": {
-				"buffer-crc32": "0.2.13"
+				"buffer-crc32": "~0.2.3"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
 		"postinstall": "node ./node_modules/vscode/bin/install",
 		"test": "node ./node_modules/vscode/bin/test"
 	},
+	"dependencies": {
+		"jsonc-parser": "^2.0.3"
+	},
 	"devDependencies": {
 		"typescript": "^3.1.4",
 		"vscode": "^1.1.25",

--- a/src/SnippetsManager.js
+++ b/src/SnippetsManager.js
@@ -77,6 +77,7 @@ class SnippetsManager {
 
             let fileContent = jsonc.applyEdits(jsonText, edit);
             fs.writeFile(snippetFile, fileContent, () => { });
+            vscode.window.showInformationMessage(`Snippet added`)
         });
 
     }

--- a/src/SnippetsManager.js
+++ b/src/SnippetsManager.js
@@ -2,6 +2,7 @@ const vscode = require('vscode');
 const os = require('os');
 const fs = require('fs');
 const util = require('util');
+const jsonc = require('jsonc-parser');
 
 class SnippetsManager {
 
@@ -38,20 +39,43 @@ class SnippetsManager {
                 return;
             }
 
-            let snippets = JSON.parse(text.toString());
+            let jsonText = text.toString();
+
+            let parsingErrors = [];
+            let snippets = jsonc.parse(jsonText, parsingErrors);
+
+            if (parsingErrors.length > 0) {
+                let errors = [];
+                parsingErrors.forEach(e => {
+                    let errorText = `'${jsonc.printParseErrorCode(e.error)}' error at offset ${e.offset}`;
+                    errors.push(errorText);
+                });
+
+                vscode.window.showErrorMessage(`Error${parsingErrors.length > 1 ? "s" : ""} on parsing current ${snippet.language} snippet file: ${errors.join(', ')}`);
+                return;
+            }
 
             if (snippets[snippet.name] !== undefined) {
                 vscode.window.showErrorMessage('A snippet with this name already exists');
                 return;
             }
 
-            snippets[snippet.name] = {
-                prefix: snippet.prefix,
-                body: snippet.body,
-                description: snippet.description
-            };
+            let edit = jsonc.modify(jsonText, [snippet.name],
+                {
+                    prefix: snippet.prefix,
+                    body: snippet.body,
+                    description: snippet.description
+                },
+                {
+                    formattingOptions: {
+                        // based on default vscode snippet format
+                        tabSize: 2,
+                        insertSpaces: false,
+                        eol: ''
+                    }
+                });
 
-            let fileContent = JSON.stringify(snippets, null, '\t');
+            let fileContent = jsonc.applyEdits(jsonText, edit);
             fs.writeFile(snippetFile, fileContent, () => { });
         });
 


### PR DESCRIPTION
The previous version used the default js `JSON.Parse` method, which, correctly, does not accept JSON files with comments.

Instead, snippets can contain comments: VSCode itself creates those files with some comments inside.
So, when this extension try to parse the snippet JSON, it go wrong and and nothing is done.

## Supporting JSON with comment
The change made uses the `jsonc-parser` library, the same used internally by VSCode to manage JSON files. It correctly parses and handles JSON files with comments

## Show parsing errors
The problem was not highlighted because there was no feedback on any parser errors. 

So, I implemented a check on errors and its alert. In this regard, the error is shown to the user through error notification and contains the error description (as defined in the `jsonc-parser` library) and the relative offset in which to find the point to be corrected. 

### Possible improvements
If you wish, it might be useful to transform the _offset_ into a _row/column reference_. VSCode already has a method to do this: `TextDocument.positionAt (offset: number)`, see [documentation](https://code.visualstudio.com/api/references/vscode-api#TextDocument). The problem is that `TextDocument` refers to files opened in the editor, while in this case the file is the stored snippet. Then you should open the file and then use the method.

## Information message
Finally I was allowed to add a small informational message that reassures the user that the snippet has been added.