### PR TITLE
Fixes code-insider detection issues, plus increments to 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to the "snippet-creator" extension will be documented in thi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+### 0.0.6
+
+- Detects and also works with VSCode `code-insiders` edition
+- Repairs blank prefix and blank description if user doesn't enter them
+- Attempting to add a snippet with an existing name now succeeds (a unique id is added to the incoming snippet)
+- Better success announcement message
+  
 ## 0.0.1 - 2019-01-02
 ### Added
  - Initial release.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,26 @@
 # Snippet Creator
 
-This extension helps to automate snippet creation. Select the code you want to create snippet from and use command "Create snippet" from command palette or your custom keybind.
-
-You can edit created snippet as usual.
+This extension helps to automate snippet creation. Select the code you want to create snippet from and use command `Create Snippet` from the command palette or your custom keybind.
 
 ## Features
 
 ![Example](https://raw.githubusercontent.com/VincentKos/vscode-snippet-creator/master/img/example.gif)
 
 
+Use `Insert Snippet` (a built-in vscode command) to select and insert your snippet.
+
+You can edit created snippets as usual because snippets created by this extension simply get added to the snippet JSON file for the relevant language.  Use the command `Preferences: Configure User Snippets` (a built-in vscode command) to select and edit your snippets file.
+
+Before this extension existed, you had to generate snippets by crafting the JSON manually or by visiting https://snippet-generator.app/ and pasting into the relevant JSON snippet file.
+
 ## Release Notes
+
+### 0.0.6
+
+- Detects and also works with VSCode `code-insiders` edition
+- Repairs blank prefix and blank description if user doesn't enter them
+- Attempting to add a snippet with an existing name now succeeds (a unique id is added to the incoming snippet)
+- Better success announcement message
 
 ### 0.0.1
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "snippet-creator",
 	"displayName": "Snippet Creator",
 	"description": "Create snippets from selection",
-	"version": "0.0.1",
+	"version": "0.0.6",
 	"icon": "img/icon.png",
 	"author": {
 		"name": "Vincent Kosciuszko",

--- a/src/SnippetsManager.js
+++ b/src/SnippetsManager.js
@@ -10,20 +10,21 @@ class SnippetsManager {
 
         let settingsPath;
         let directorySeparator = '/';
+        let vscode_subdir = (vscode.env.appName.includes("Visual Studio Code - Insiders") ? 'Code - Insiders' : 'Code')
 
         switch (os.type()) {
             case 'Darwin':
-                settingsPath = process.env.HOME + '/Library/Application Support/Code/User/';
+                settingsPath = process.env.HOME + `/Library/Application Support/${vscode_subdir}/User/`;
                 break;
             case 'Linux':
-                settingsPath = process.env.HOME + "/.config/Code/User/";
+                settingsPath = process.env.HOME + `/.config/${vscode_subdir}/User/`;
                 break;
             case 'Windows_NT':
-                settingsPath = process.env.APPDATA + "\\Code\\User\\";
+                settingsPath = process.env.APPDATA + `\\${vscode_subdir}\\User\\`;
                 directorySeparator = "\\";
                 break;
             default:
-                settingsPath = process.env.HOME + "/.config/Code/User/";
+                settingsPath = process.env.HOME + `/.config/${vscode_subdir}/User/`;
                 break;
         }
 
@@ -56,9 +57,15 @@ class SnippetsManager {
             }
 
             if (snippets[snippet.name] !== undefined) {
-                vscode.window.showErrorMessage('A snippet with this name already exists');
-                return;
+                vscode.window.showErrorMessage(`A snippet '${snippet.name}' already exists - so adding a unique id`);
+                // return;
+                snippet.name = snippet.name + '_' + this.uuidv4()
             }
+
+            if (snippet.prefix == "")
+                snippet.prefix = snippet.name;
+            if (snippet.description == "")
+                snippet.description = snippet.name + ' description';
 
             let edit = jsonc.modify(jsonText, [snippet.name],
                 {
@@ -77,10 +84,17 @@ class SnippetsManager {
 
             let fileContent = jsonc.applyEdits(jsonText, edit);
             fs.writeFile(snippetFile, fileContent, () => { });
-            vscode.window.showInformationMessage(`Snippet added`)
+            vscode.window.showInformationMessage(`Snippet '${snippet.prefix}' added to ${snippet.language} snippets`)
         });
 
     }
+
+    uuidv4() {
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+            return v.toString(16);
+        });
+    }    
 
 }
 


### PR DESCRIPTION
A bunch of fixes and improvements - sorry they are bundled in one hit, but I got onto a roll and addressed all the issues that were bugging me and possibly others.

- Detects and also works with VSCode `code-insiders` edition
- Repairs blank prefix and blank description if user doesn't enter them
- Attempting to add a snippet with an existing name now succeeds (a unique id is added to the incoming snippet)
- Better success announcement message
- increments to 0.0.6 so that it supercedes the deprecated 0.0.5 version more obviously
- A bit more helpful info added to the readme
